### PR TITLE
mosaic, test and compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MakieMaestro"
 uuid = "c922e6f1-a74a-406e-9215-09b2647b2648"
 authors = ["Martin Kunz <martinkunz@email.cz> and contributors"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,9 +5,11 @@ using MakieMaestro
 
 # NOTE: When updating, must update also in `test/runtests.jl` and `test/fix_doctests.jl`<18-12-24> 
 DocMeta.setdocmeta!(
-    MakieMaestro, :DocTestSetup, :(using MakieMaestro;
-    using Logging; # NOTE: This does not need to be in the `make.jl` of docs. We want `@warn ` to function there <19-12-24> 
-    Logging.disable_logging(Logging.Warn)); recursive=true
+    MakieMaestro, :DocTestSetup, :(
+        include(joinpath(@__DIR__, "..", "test/doctestsetup.jl"));
+        using MakieMaestro;
+        using Logging; # NOTE: This does not need to be in the `make.jl` of docs. We want `@warn ` to function there <19-12-24> 
+        Logging.disable_logging(Logging.Warn)); recursive=true
 )
 
 # NOTE: Links can be explored trough the REPL with `links(query)`

--- a/src/MakieMaestro.jl
+++ b/src/MakieMaestro.jl
@@ -1,4 +1,5 @@
 # TODO: Overload ± to select a window around a index <06-03-25> 
+# TODO: Get the defaults figure dir and size and export format from the environment or the .env file <14-07-25> 
 module MakieMaestro
 using Reexport
 @reexport using Unitful

--- a/src/ensemble-recipes.jl
+++ b/src/ensemble-recipes.jl
@@ -67,6 +67,8 @@ function create_axes!(
         ax_inds = sort!([
             (i, j) for i in 1:nrows, j in 1:ncols if ((j - 1) * nrows) + i <= naxes
         ])
+    else
+        ax_inds = [(i, j) for i in 1:nrows, j in 1:ncols]
     end
 
     @assert length(ax_inds) == naxes

--- a/src/ensemble-recipes.jl
+++ b/src/ensemble-recipes.jl
@@ -15,26 +15,88 @@ using Makie: Makie
 # mosaic(mat2; axis = (; title = map(string, 1:9)), plt=surface!)
 # mosaic(mat2; axis = (; title = map(string, 1:9)), plt=heatmap!)
 
-"""
-    mosaic(datas::AbstractVector; 
-            nrows, ncols,
-           plt=Recipes.image!, ax_func! = identity, linkaxes=true, vargs...)
-    mosaic(datas::Stack, args...; vargs...)
-    mosaic(datas::AbstractMatrix; vargs...)
+# TODO: Should instead take a plotting function that can take any iterable data and plot it into the supplied axis or
+# GridCell or indexed figure <22-07-25> 
 
-Create a grid-like arrangement of plots.
+# TODO: Add support for vector like `kwargs` with length of number of data <28-07-25> 
+# TODO: Now there is support for single function multiple data. Add support for multiple functions single data <28-07-25> 
+function mosaic!(fn::Function, axs::AbstractArray{<:Makie.AbstractAxis}, data...; kwargs...)
+    @assert length(data) == length(axs) "Number of `data`s is not equal to the length of `axs`"
+    plts = map(axs, data) do a, d
+        fn(a, d; kwargs...)
+    end
+    return plts
+end
+
+function mosaic!(axs::AbstractArray{<:Makie.AbstractAxis}, data...)
+    return mosaic!(Makie.plot!, axs, data...)
+end
+
+function create_figure(; figure=(;)) end
+
+const FigureLike = Union{Makie.Figure,Makie.GridPosition,Makie.GridSubposition}
+
+function create_axes!(
+    f::FigureLike, naxes; nrows=nothing, ncols=nothing, axis=(;), linkaxes=true
+)
+    if isnothing(nrows) && isnothing(ncols)
+        forced_dim = :nrows
+        nrows = 1
+        ncols = ceil(Int, naxes / nrows)
+    elseif isnothing(ncols)
+        forced_dim = :nrows
+        @assert nrows isa Integer "`ncols` must be an integer"
+        ncols = ceil(Int, naxes / nrows)
+    elseif isnothing(nrows)
+        forced_dim = :ncols
+        @assert ncols isa Integer "`nrows` must be an integer"
+        nrows = ceil(Int, naxes / ncols)
+    else # specified both `nrows` and `ncols`
+        forced_dim = :none
+        @assert nrows * ncols == naxes "Data length must match nrows * ncols"
+    end
+
+    axis_multi = filter(v -> v isa Vector && length(v) == naxes, axis)
+    axis_single = filter(v -> !(v isa Vector) || length(v) != naxes, axis)
+
+    if forced_dim == :nrows
+        ax_inds = sort!([
+            (i, j) for i in 1:nrows, j in 1:ncols if ((i - 1) * ncols) + j <= naxes
+        ])
+    elseif forced_dim == :ncols
+        ax_inds = sort!([
+            (i, j) for i in 1:nrows, j in 1:ncols if ((j - 1) * nrows) + i <= naxes
+        ])
+    end
+
+    @assert length(ax_inds) == naxes
+
+    ax = [Makie.Axis(f[i...]; axis_single...) for i in ax_inds]
+
+    # TODO: Could be done in the construction <28-07-25> 
+    for k in keys(axis_multi)
+        for (i, v) in enumerate(axis_multi[k])
+            setproperty!(ax[i], k, v)
+        end
+    end
+
+    if linkaxes
+        Makie.linkaxes!(ax...)
+    end
+    return ax
+end
+
+"""
+    mosaic([fn::Function=plot!], data...; <keyword-args>)
+    mosaic([fn::Function=plot!], datas::AbstractMatrix; <keyword-args>)
+
+Create a grid-like arrangement of plots. If passed a `Matrix` of objects to plot, the number of rows and columns is
+preserved in the grid.
 
 # Arguments
-- `datas`: Vector, 3D array, or matrix of data to be plotted
 - `nrows` / `ncols`: Number of rows / columns
-- `plt`: Plotting function to apply (default: `image!`)  
-- `ax!`: Function to modify axis properties (default: identity)
 - `linkaxes`: Boolean to control axis linking (default: true)
-- `vargs...`: Additional plotting arguments passed to the plotting function
-
-The function creates a Makie Figure object with a grid of plots, applies the specified 
-plotting function to each data element, and returns the resulting figure. It supports 
-vectorized arguments that match the data length and automatically handles tuple-packed data.
+- `vargs...`: Additional plotting arguments are passed to the plotting function
 
 # Returns
 - A Makie Figure object containing the mosaic of plots that have linked axes
@@ -55,67 +117,27 @@ fig = mosaic(datamat)
 ```
 """
 function mosaic(
-    datas::AbstractVector;
+    fn::Function,
+    data::Vararg;
     nrows=nothing,
     ncols=nothing,
-    plt=Recipes.image!,
-    (ax!)=identity,
+    figure=(;),
     axis=(;),
     linkaxes=true,
-    vargs...,
+    kwargs...,
 )
-    if isnothing(nrows) && isnothing(ncols)
-        forced_dim = :nrows
-        nrows = 1
-        ncols = ceil(Int, length(datas) / nrows)
-    elseif isnothing(ncols)
-        forced_dim = :nrows
-        @assert nrows isa Integer "`ncols` must be an integer"
-        ncols = ceil(Int, length(datas) / nrows)
-    elseif isnothing(nrows)
-        forced_dim = :ncols
-        @assert ncols isa Integer "`nrows` must be an integer"
-        nrows = ceil(Int, length(datas) / ncols)
-    else
-        forced_dim = :none
-        @assert nrows * ncols == length(datas) "Data length must match nrows * ncols"
-    end
+    f = Makie.Figure(; figure...)
+    ax = create_axes!(
+        f, length(data); nrows=nrows, ncols=ncols, axis=axis, linkaxes=linkaxes
+    )
 
-    f = Makie.Figure(;)
-    # TODO: Filter the others out and apply them in the axis creations <17-11-24> 
-    v_axis_vargs = filter(v -> v isa Vector && length(v) == length(datas), axis)
-    ax = [Makie.Axis(f[i, j]) for i in 1:nrows, j in 1:ncols]
-
-    for k in keys(v_axis_vargs)
-        for (i, v) in enumerate(v_axis_vargs[k])
-            setproperty!(ax[i], k, v)
-        end
-    end
-
-    if forced_dim == :nrows
-        delete!.(ax[(length(datas) + 1):end]) # remove the empty axes
-    elseif forced_dim == :ncols
-        rest = ncols * nrows - length(datas)
-        if rest != 0
-            delete!.(ax[(end - rest + 1):end, end]) # remove the empty axes
-        end
-    end
-
-    vector_vargs = filter(v -> v isa Vector && length(v) == length(datas), vargs)
-    for (ind, (a, data)) in enumerate(zip(ax[:], datas))
-        a_vargs = NamedTuple(
-            map((k, v) -> k => v[ind], zip(keys(vector_vargs), vector_vargs))
-        )
-        if data isa Tuple # unpack the data if it is a tuple
-            plt(a, data...; a_vargs..., vargs...)
-        else
-            plt(a, data; a_vargs..., vargs...)
-        end
-        ax!(a)
-    end
-    Makie.linkaxes!(ax...)
-    return f
+    return f, ax, mosaic!(fn, ax, data...; kwargs...)
 end
+
+function mosaic(args...; kwargs...)
+    return mosaic(Makie.plot!, args...; kwargs...)
+end
+
 const Stack = AbstractArray{T,3} where {T}
 function mosaic(datas::Stack; vargs...)
     return mosaic(eachslice(datas; dims=3); vargs...)

--- a/src/recipe-modifications.jl
+++ b/src/recipe-modifications.jl
@@ -67,7 +67,7 @@ function Recipes.image(args...; _axis=(; aspect=Makie.DataAspect()), axis=(;), k
     attributes = Dict{Symbol,Any}(kwargs..., :axis => axis)
     figkws = Makie.fig_keywords!(attributes)
 
-    plot = Plot{Makie.default_plot_func(Image, pargs)}(pargs, attributes)
+    plot = Plot{Makie.image}(pargs, attributes)
     figax = Makie.create_axis_like(plot, figkws, figarg)
     ax = figax isa Makie.FigureAxis ? figax.axis : figax
 

--- a/test/doctestsetup.jl
+++ b/test/doctestsetup.jl
@@ -1,0 +1,1 @@
+using MakieMaestro

--- a/test/documenter.jl
+++ b/test/documenter.jl
@@ -1,0 +1,8 @@
+using Documenter
+ext = Base.get_extension(MakieMaestro, :DocumenterExt)
+@assert !isnothing(ext)
+@test ext.MakieBlockOptions(name="name1") == parse(ext.MakieBlockOptions, " name1")
+@test ext.MakieBlockOptions(name="name2", basename="basename1") == parse(ext.MakieBlockOptions, " name2; basename=\"basename1\"")
+@test ext.MakieBlockOptions(name="name2", caption="caption1") == parse(ext.MakieBlockOptions, " name2; caption=\"caption1\"")
+@test ext.MakieBlockOptions(name="name2", basename="basename1") == parse(ext.MakieBlockOptions, " name2; formats = [:png, :pdf] , basename=\"basename1\"")
+@test ext.MakieBlockOptions(name="name2", basename="basename1", caption="caption1") == parse(ext.MakieBlockOptions, " name2; caption = \"caption1\" , basename=\"basename1\"")

--- a/test/exporting.jl
+++ b/test/exporting.jl
@@ -1,0 +1,287 @@
+function fig_function_w_kwargs(lims::Tuple{Real,Real}=(0, 1); N=100)
+    f = Figure()
+    ax = Axis(f[1, 1])
+    xs = LinRange(lims..., N)
+    lines!(ax, xs, sin.(xs))
+    return f
+end
+
+fig_function(lims::Tuple{Real,Real}=(0, 1)) = fig_function_w_kwargs(lims)
+
+@testset "format" begin
+    using MakieMaestro: Format, extension
+
+    @test parse(Format, "png") == MakieMaestro.Png
+    @test_throws ArgumentError parse(Format, "pngx")
+    @test parse(Format, "pdf") == MakieMaestro.Pdf
+
+    @test extension(MakieMaestro.Pdf) == ".pdf"
+    @test extension(MakieMaestro.PdfTex) == ".pdf"
+end
+
+@testset "Argument transformation cascade" begin
+    @testset "FunctionSpec" begin
+        using MakieMaestro: FunctionSpec
+        @test FunctionSpec(fig_function) isa FunctionSpec
+        fspec_1 = FunctionSpec(fig_function)
+        @test FunctionSpec(fig_function, ((-π, π),)) isa FunctionSpec
+        fspec_2 = FunctionSpec(fig_function, ((-π, π),))
+        @test fspec_1() isa Figure
+        @test fspec_2() isa Figure
+        @test nameof(fspec_1) == nameof(fspec_2) == :fig_function
+
+        @test FunctionSpec(fig_function_w_kwargs) isa FunctionSpec
+        fspec_3 = FunctionSpec(fig_function_w_kwargs)
+        @test FunctionSpec(fig_function_w_kwargs, ((-π, π),)) isa FunctionSpec
+        fspec_4 = FunctionSpec(fig_function_w_kwargs, ((-π, π),))
+        @test fspec_3() isa Figure
+        @test fspec_4(; N=300) isa Figure
+    end
+
+    @testset "PathSpec" begin
+        using MakieMaestro
+        using MakieMaestro: PathSpec
+
+        @test_throws ArgumentError PathSpec(
+            "test", Set([MakieMaestro.Png]), "testdir"
+        ) # NOTE: Non-existent directory
+        dir = pwd()
+        @test PathSpec("test.pdf", dir) isa PathSpec
+        @test PathSpec(joinpath(dir, "test.png")) isa PathSpec
+        pnfs_1 = PathSpec(joinpath(dir, "test.png"))
+        @test MakieMaestro.Png in pnfs_1.formats
+        @test pnfs_1.dirname == dir
+        @test pnfs_1.basename(0) == "test"
+        @test pnfs_1.basename(1) == "test_1"
+        @test pnfs_1.basename(2) == "test_2"
+
+        @test PathSpec(joinpath(dir, "test.{png,svg,pdf,pdf_tex}")) isa PathSpec
+        @test PathSpec(joinpath(dir, "test.{png, svg, pdf, pdf_tex}")) isa PathSpec # NOTE: With spaces
+        pnfs_2 = PathSpec(joinpath(dir, "test.{png,svg,pdf,pdf_tex}"))
+        @test Set([
+            MakieMaestro.Png,
+            MakieMaestro.Svg,
+            MakieMaestro.Pdf,
+            MakieMaestro.PdfTex,
+        ]) ⊆ pnfs_2.formats
+
+        @test_throws ArgumentError PathSpec(joinpath(dir, "test.{pdf, png"))
+        @test_throws ArgumentError PathSpec(joinpath(dir, "test.pdf, png}"))
+        @test_throws ErrorException PathSpec(joinpath(dir, "testpdf")) # no default format set
+
+        export_format!(Set([MakieMaestro.Pdf]))
+        if !haskey(ENV, "GITHUB_ACTIONS") # NOTE: tmp directories do not work as expected in the CI <31-01-25> 
+            temp_dir = mkdir(joinpath(tempdir(), "mm_test_dir/"))
+            cd(temp_dir)
+            @test PathSpec("testpdf") isa PathSpec
+            rm(temp_dir; recursive=true)
+        end
+        @test MakieMaestro.Pdf in PathSpec(joinpath(dir, "testpdf")).formats
+        @test PathSpec("test", dir) isa PathSpec
+
+        @test_throws ArgumentError PathSpec(
+            joinpath(dir, "test.{png,svgpdf}"), # invalid extension
+        )
+
+        @test PathSpec("test", [:png, "svg", MakieMaestro.PdfTex], dir) isa PathSpec
+    end
+
+    @testset "sizing" begin
+        using MakieMaestro: SizeSpec, RelativeSize
+        using MakieMaestro.Themes
+        width!(MakieMaestro.Themes.A4_WIDTH)
+
+        @test RelativeSize(0.5) isa RelativeSize
+        @test_throws ArgumentError RelativeSize(-0.5)
+
+        @test SizeSpec() isa SizeSpec
+        @test SizeSpec(30u"cm") isa SizeSpec
+        @test SizeSpec(RelativeSize(0.5)) isa SizeSpec
+        @test SizeSpec(0.5) isa SizeSpec
+        @test SizeSpec(0.5) == SizeSpec(RelativeSize(0.5))
+        @test SizeSpec(30u"cm", 0.5) isa SizeSpec
+        @test SizeSpec(0.5, 0.5) isa SizeSpec
+        @test_throws ArgumentError SizeSpec(0.5, -0.5) isa SizeSpec
+
+        @test FigHeight(0.5) isa FigHeight
+        @test FigHeight(30u"cm") isa FigHeight
+
+        @test SizeSpec(FigHeight(30u"cm"), 0.5) isa SizeSpec
+        @test SizeSpec(FigHeight(0.5), 0.5) isa SizeSpec
+    end
+end
+
+@testset "`savefig`" begin
+    # NOTE: Prepare 
+    fig_dir = joinpath(tempdir(), "test_fig_dir")
+    mkdir(fig_dir)
+    figure_dir!(fig_dir)
+    width!(0.8MakieMaestro.Themes.A4_WIDTH)
+    @test MakieMaestro.Pdf in export_format!(Set([MakieMaestro.Pdf]))
+
+    @testset "utils" begin
+        @test MakieMaestro.get_formats([CairoMakie], Set([MakieMaestro.Png])) ==
+              [MakieMaestro.Png] # Allowed formats
+        if Sys.which("inkscape") !== nothing
+            @test MakieMaestro.Svg in
+                  MakieMaestro.get_formats([CairoMakie], Set([MakieMaestro.PdfTex])) # Added necessary Svg format
+        end
+        @test_throws ArgumentError MakieMaestro.get_formats(
+            [GLMakie], Set([MakieMaestro.Pdf])
+        )
+    end
+
+    @testset "method availability" begin
+        figexists(name) = isfile(joinpath(fig_dir, name))
+        rmfig(name) = rm(joinpath(fig_dir, name))
+        issamefig(a, b) =
+            success(`cmp --quiet $(joinpath(fig_dir, a)) $(joinpath(fig_dir, b))`)
+
+        # Basic methods
+        savefig(fig_function)
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        savefig(fig_function_w_kwargs)
+        @test figexists("fig_function_w_kwargs.pdf")
+        rmfig("fig_function_w_kwargs.pdf")
+
+        # TODO: Add note to the documentation about the need to add the comma in order for the argument to be
+        # parsed as a tuple and not normal parens <30-01-25> 
+        savefig(fig_function, ((-π, π),))
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        if Sys.which("cmp") !== nothing # Check if UNIX system command exists
+            savefig(fig_function, ["svg"])
+            # NOTE: Comparison may not be made with `pdf` because the file is not the same even with the same
+            # figure <30-01-25> 
+            # NOTE: Different `N`. Should not be the same as `fig_function`
+            savefig(fig_function_w_kwargs, ["svg"]; N=300)
+            @test !issamefig("fig_function_w_kwargs.svg", "fig_function.svg")
+            # NOTE: Same `N`. Should be the same as `fig_function`
+            savefig(fig_function_w_kwargs, ["svg"]; N=100)
+            @test issamefig("fig_function_w_kwargs.svg", "fig_function.svg")
+            rmfig.(("fig_function_w_kwargs.svg", "fig_function.svg"))
+        end
+
+        if Sys.which("inkscape") !== nothing
+            savefig(fig_function, ["pdf_tex"])
+            @test figexists("fig_function.pdf_tex")
+            rmfig("fig_function.pdf_tex")
+        end
+
+        # Multiple formats
+        savefig(fig_function, ["svg", MakieMaestro.Pdf])
+        @test all(figexists.(("fig_function.svg", "fig_function.pdf")))
+        rmfig.(("fig_function.svg", "fig_function.pdf"))
+
+        savefig(fig_function, "name.{pdf,png}")
+        @test all(figexists.(("name.pdf", "name.png")))
+        rmfig.(("name.pdf", "name.png"))
+
+        # Specifying a different name
+        savefig(fig_function, "other_name")
+        @test figexists("other_name.pdf")
+        rmfig("other_name.pdf")
+
+        savefig(fig_function, "other_name", ["svg", :pdf])
+        @test all(figexists.(("other_name.pdf", "other_name.svg")))
+        rmfig.(("other_name.pdf", "other_name.svg"))
+
+        # Specifying the figure directory
+        alt_fig_dir = joinpath(tempdir(), "alt_fig_dir")
+        mkdir(alt_fig_dir)
+        savefig(fig_function, "name1", alt_fig_dir)
+        savefig(fig_function, "name2", ["pdf"], alt_fig_dir)
+        savefig(fig_function, joinpath(alt_fig_dir, "name3"), ["pdf"])
+        savefig(fig_function, joinpath(alt_fig_dir, "name4.pdf"))
+        @test any(
+            figexists.(("name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"))
+        ) == false
+        @test all(
+            isfile.(
+                map(
+                    n -> joinpath(alt_fig_dir, n),
+                    ["name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"],
+                )
+            ),
+        )
+        rm.(
+            map(
+                n -> joinpath(alt_fig_dir, n),
+                ["name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"],
+            )
+        )
+        rm(alt_fig_dir; recursive=true)
+
+        # Sizing 
+        savefig(fig_function, 100u"cm")
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        if Sys.which("cmp") !== nothing # Check if UNIX system command exists
+            savefig(fig_function, "orig_size.svg")
+
+            savefig(
+                fig_function, "relative_size_one.svg", MakieMaestro.RelativeSize(1)
+            )
+            savefig(fig_function, "relative_size_one_notyping.svg", 1)
+            @test issamefig("orig_size.svg", "relative_size_one.svg")
+            @test issamefig("orig_size.svg", "relative_size_one_notyping.svg")
+
+            savefig(fig_function, "width_same.svg", MakieMaestro.Themes.get_width())
+            @test issamefig("orig_size.svg", "width_same.svg")
+
+            savefig(
+                fig_function,
+                "hwratio_same.svg",
+                1,
+                MakieMaestro.Themes.get_hwratio(),
+            )
+            @test issamefig("orig_size.svg", "hwratio_same.svg")
+
+            rmfig.((
+                "orig_size.svg",
+                "relative_size_one.svg",
+                "width_same.svg",
+                "hwratio_same.svg",
+            ))
+        end
+
+        # NOTE: Warns that the error may be thrown due to SizeSpec arguments being passed to
+        # fig_function <31-01-25> 
+        using Logging
+        Logging.disable_logging(Logging.Info) # NOTE: Must enable logging after DocTests
+        # l = TestLogger()
+        # Logging.with_logger(l) do
+        #     try
+        @test_logs (:warn,) @test_throws MethodError savefig(
+            fig_function, (100u"cm", 0.6)
+        )
+        @test_logs (:warn,) @test_throws MethodError savefig(
+            fig_function, (0.7, 10u"cm")
+        )
+        Logging.disable_logging(Logging.Warn)
+        @test_nowarn savefig(FunctionSpec(fig_function), (10u"cm", 10u"cm"))
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        savefig(fig_function, FigHeight(100u"cm"))
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        savefig(fig_function, 100u"cm", 0.6)
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+
+        savefig(fig_function, FigHeight(100u"cm"), 0.6)
+        @test figexists("fig_function.pdf")
+        rmfig("fig_function.pdf")
+    end
+
+    # NOTE: Destroy
+    rm(fig_dir; recursive=true)
+    export_format!(missing)
+    MakieMaestro.Themes.WIDTH_DEFAULT[] = missing
+end

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -1,0 +1,7 @@
+using MakieMaestro.Recipes
+
+f = Figure()
+for (arg,kw) in [((f,10), (;nrows=2)), ((f, 10),(;ncols=2)), ((f,10), (;nrows=2, ncols=5)), ((f[1,1], 10,), (; nrows=2, ncols=5)), ((f[1,1][1,1], 10,), (; nrows=2, ncols=5))]
+    ax = Recipes.create_axes!(arg...; kw...)
+    @test length(ax) == arg[2]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,382 +5,86 @@ using Aqua
 
 include("./tools.jl")
 
+const run_all = isempty(ARGS) ? true : false
+
+skip = Dict{String,Bool}(
+    "compat" => !(VERSION >= v"1.9"), # NOTE: `CompatHelperLocal` only compatible with later Julia version <28-02-25> 
+    "aqua" => !haskey(ENV, "GITHUB_ACTIONS") && !haskey(ENV, "RUNTESTS_FULL"),
+    "doctests" => !haskey(ENV, "RUNTESTS_FULL") && !(haskey(ENV, "RUNNER_OS") && ENV["RUNNER_OS"] == "Linux"),
+    "ambiguities" => true # FIX: Fix the ambiguities <24-04-25> 
+)
+
+function should_test(arg::String)::Bool
+    global run_all
+    if run_all
+        return !get(skip, arg, false)
+    elseif arg in ARGS
+        return true
+    end
+    return false
+end
+
+macro cond_testset(name, block)
+    quote
+        if should_test($name)
+            @testset $name begin
+                esc($block)
+            end
+        end
+    end
+end
+
 @testset "MakieMaestro.jl" begin
     @testset "Code quality" begin
-        @testset "Aqua.jl" begin
-            if haskey(ENV, "RUNTESTS_FULL") || haskey(ENV, "GITHUB_ACTIONS")
-                Aqua.test_all(MakieMaestro; ambiguities=false)
+        @cond_testset "aqua" begin
+            Aqua.test_all(
+                MakieMaestro;
+                ambiguities=false,
+            )
+        end
+
+        @cond_testset "ambiguities" begin
+            aqua_ambiguities = false
+            if aqua_ambiguities
+                Agua.test_ambiguities(MakieMaestro)
             else
-                @info "Skipping Aqua.jl quality tests. For a full run set `ENV[\"RUNTESTS_FULL\"]=true`."
+                @test length(Test.detect_ambiguities(MakieMaestro)) == 0
             end
         end
-        @testset "Ambiguities" begin
-            @test length(Test.detect_ambiguities(MakieMaestro)) == 0
-        end
-        @testset "Compat" begin
-            CompatHelperLocal.@check(checktest = false)
+
+        @cond_testset "compat" begin
+            @test CompatHelperLocal.check(MakieMaestro; checktest=false)
         end
     end
-    @testset "DocTests" begin
+
+    @cond_testset "doctests" begin
+        # FIX: When running locally, do not ask for SSH key password <10-12-23> 
         # NOTE: Show for `Unitful.jl` does nm⁻¹ on macOS and nm^-1 on Linux. This is necessary, since the `jldoctest` is only one
-        if !haskey(ENV, "GITHUB_ACTIONS") ||
-           haskey(ENV, "RUNNER_OS") && ENV["RUNNER_OS"] == "Linux"
-            # NOTE: Better than doc-testing in `make.jl` because, I can track the coverage
-            # NOTE: When updating, must update also in `docs/make.jl` and  `test/fix_doctests.jl`<18-12-24> 
-            DocMeta.setdocmeta!(
-                MakieMaestro,
-                :DocTestSetup,
-                :(using MakieMaestro;
+        # NOTE: Better than doc-testing in `make.jl` because, I can track the coverage
+        # NOTE: Show for `Unitful.jl` does nm⁻¹ on macOS and nm^-1 on Linux. This is necessary, since the `jldoctest` is only one
+        DocMeta.setdocmeta!(
+            MakieMaestro,
+            :DocTestSetup,
+            :(
+                include(joinpath(@__DIR__, "doctestsetup.jl"));
                 using Logging; # NOTE: This does not need to be in the `make.jl` of docs. We want `@warn ` to function there <19-12-24> 
                 Logging.disable_logging(Logging.Warn));
-                recursive=true,
-            )
-            doctest(MakieMaestro)
-        end
+            recursive=true,
+        )
+        !haskey(ENV, "FIX_DOCTESTS") && @info "You can fix doctests by setting `ENV[\"FIX_DOCTESTS\"] = true`."
+        doctest(MakieMaestro; fix=ifelse(haskey(ENV, "FIX_DOCTESTS"), true, false))
     end
-    @testset "Theming" begin
-        @testset "Constants" begin
-            using MakieMaestro.Themes
-            @test Themes.A4_HEIGHT == 297u"mm"
-            @test Themes.A11_WIDTH == 18u"mm" # Test for rounding down
 
-            @test Themes.A3_HEIGHT == Themes.A2_WIDTH == 420u"mm"
-            @test Themes.B6_WIDTH == 125u"mm"
-            @test Themes.C10_HEIGHT == 40u"mm"
-        end
-        @testset "merge_generate" begin
-            using MakieMaestro.Themes: merge_generate, ThemeGenerator, get_theme, THEME
-            @test THEME[][:base] isa ThemeGenerator
-            @test THEME[][:size] isa ThemeGenerator
-            @test THEME[][:format_ticks] isa ThemeGenerator
-
-            f_themegenerator = () -> Theme(; figure_padding=3)
-            @test f_themegenerator isa ThemeGenerator
-            @test theme_latexfonts isa ThemeGenerator
-            @test issame(
-                merge_generate(f_themegenerator, theme_latexfonts),
-                Theme(; figure_padding=3, fonts=theme_latexfonts()[:fonts]),
-            )
-            @test merge_generate(THEME[][:size](5u"cm", 0.5)) isa Theme
-
-            # NOTE: Test correct precedence  
-            @test issame(
-                merge_generate(THEME[][:size](5u"cm", 0.5), THEME[][:size](10u"cm", 0.5)),
-                THEME[][:size](10u"cm", 0.5),
-            )
-            # NOTE: This is inconsistent in the MakieCore package. The precedence is reversed from the `merge` on
-            # dictionaries. https://github.com/MakieOrg/Makie.jl/issues/1939
-            @test_broken Base.merge(
-                THEME[][:size](5u"cm", 0.5), THEME[][:size](10u"cm", 0.5)
-            ) == THEME[][:size](10u"cm", 0.5)
-
-            @test get_theme(:base, :rotate_labels, :orange_title) isa Theme
-            @test get_theme([:base, :rotate_labels, :orange_title]) isa Theme
-
-            @test issame(get_theme(:orange_title), get_theme([:orange_title]))
-            @test issame(
-                get_theme(:base, :rotate_labels, :orange_title),
-                get_theme([:base, :rotate_labels, :orange_title]),
-            )
-        end
+    @cond_testset "theming" begin
+        include("theming.jl")
     end
-    @testset "Exporting" begin
-        function fig_function_w_kwargs(lims::Tuple{Real,Real}=(0, 1); N=100)
-            f = Figure()
-            ax = Axis(f[1, 1])
-            xs = LinRange(lims..., N)
-            lines!(ax, xs, sin.(xs))
-            return f
-        end
 
-        fig_function(lims::Tuple{Real,Real}=(0, 1)) = fig_function_w_kwargs(lims)
-
-        @testset "format" begin
-            using MakieMaestro: Format, extension
-
-            @test parse(Format, "png") == MakieMaestro.Png
-            @test_throws ArgumentError parse(Format, "pngx")
-            @test parse(Format, "pdf") == MakieMaestro.Pdf
-
-            @test extension(MakieMaestro.Pdf) == ".pdf"
-            @test extension(MakieMaestro.PdfTex) == ".pdf"
-        end
-
-        @testset "Argument transformation cascade" begin
-            @testset "FunctionSpec" begin
-                using MakieMaestro: FunctionSpec
-                @test FunctionSpec(fig_function) isa FunctionSpec
-                fspec_1 = FunctionSpec(fig_function)
-                @test FunctionSpec(fig_function, ((-π, π),)) isa FunctionSpec
-                fspec_2 = FunctionSpec(fig_function, ((-π, π),))
-                @test fspec_1() isa Figure
-                @test fspec_2() isa Figure
-                @test nameof(fspec_1) == nameof(fspec_2) == :fig_function
-
-                @test FunctionSpec(fig_function_w_kwargs) isa FunctionSpec
-                fspec_3 = FunctionSpec(fig_function_w_kwargs)
-                @test FunctionSpec(fig_function_w_kwargs, ((-π, π),)) isa FunctionSpec
-                fspec_4 = FunctionSpec(fig_function_w_kwargs, ((-π, π),))
-                @test fspec_3() isa Figure
-                @test fspec_4(; N=300) isa Figure
-            end
-
-            @testset "PathSpec" begin
-                using MakieMaestro
-                using MakieMaestro: PathSpec
-
-                @test_throws ArgumentError PathSpec(
-                    "test", Set([MakieMaestro.Png]), "testdir"
-                ) # NOTE: Non-existent directory
-                dir = pwd()
-                @test PathSpec("test.pdf", dir) isa PathSpec
-                @test PathSpec(joinpath(dir, "test.png")) isa PathSpec
-                pnfs_1 = PathSpec(joinpath(dir, "test.png"))
-                @test MakieMaestro.Png in pnfs_1.formats
-                @test pnfs_1.dirname == dir
-                @test pnfs_1.basename(0) == "test"
-                @test pnfs_1.basename(1) == "test_1"
-                @test pnfs_1.basename(2) == "test_2"
-
-                @test PathSpec(joinpath(dir, "test.{png,svg,pdf,pdf_tex}")) isa PathSpec
-                @test PathSpec(joinpath(dir, "test.{png, svg, pdf, pdf_tex}")) isa PathSpec # NOTE: With spaces
-                pnfs_2 = PathSpec(joinpath(dir, "test.{png,svg,pdf,pdf_tex}"))
-                @test Set([
-                    MakieMaestro.Png,
-                    MakieMaestro.Svg,
-                    MakieMaestro.Pdf,
-                    MakieMaestro.PdfTex,
-                ]) ⊆ pnfs_2.formats
-
-                @test_throws ArgumentError PathSpec(joinpath(dir, "test.{pdf, png"))
-                @test_throws ArgumentError PathSpec(joinpath(dir, "test.pdf, png}"))
-                @test_throws ErrorException PathSpec(joinpath(dir, "testpdf")) # no default format set
-
-                export_format!(Set([MakieMaestro.Pdf]))
-                if !haskey(ENV, "GITHUB_ACTIONS") # NOTE: tmp directories do not work as expected in the CI <31-01-25> 
-                    temp_dir = mkdir(joinpath(tempdir(), "mm_test_dir/"))
-                    cd(temp_dir)
-                    @test PathSpec("testpdf") isa PathSpec
-                    rm(temp_dir; recursive=true)
-                end
-                @test MakieMaestro.Pdf in PathSpec(joinpath(dir, "testpdf")).formats
-                @test PathSpec("test", dir) isa PathSpec
-
-                @test_throws ArgumentError PathSpec(
-                    joinpath(dir, "test.{png,svgpdf}"), # invalid extension
-                )
-
-                @test PathSpec("test", [:png, "svg", MakieMaestro.PdfTex], dir) isa PathSpec
-            end
-
-            @testset "sizing" begin
-                using MakieMaestro: SizeSpec, RelativeSize
-                using MakieMaestro.Themes
-                width!(MakieMaestro.Themes.A4_WIDTH)
-
-                @test RelativeSize(0.5) isa RelativeSize
-                @test_throws ArgumentError RelativeSize(-0.5)
-
-                @test SizeSpec() isa SizeSpec
-                @test SizeSpec(30u"cm") isa SizeSpec
-                @test SizeSpec(RelativeSize(0.5)) isa SizeSpec
-                @test SizeSpec(0.5) isa SizeSpec
-                @test SizeSpec(0.5) == SizeSpec(RelativeSize(0.5))
-                @test SizeSpec(30u"cm", 0.5) isa SizeSpec
-                @test SizeSpec(0.5, 0.5) isa SizeSpec
-                @test_throws ArgumentError SizeSpec(0.5, -0.5) isa SizeSpec
-
-                @test FigHeight(0.5) isa FigHeight
-                @test FigHeight(30u"cm") isa FigHeight
-
-                @test SizeSpec(FigHeight(30u"cm"), 0.5) isa SizeSpec
-                @test SizeSpec(FigHeight(0.5), 0.5) isa SizeSpec
-            end
-        end
-
-        @testset "`savefig`" begin
-            # NOTE: Prepare 
-            fig_dir = joinpath(tempdir(), "test_fig_dir")
-            mkdir(fig_dir)
-            figure_dir!(fig_dir)
-            width!(0.8MakieMaestro.Themes.A4_WIDTH)
-            @test MakieMaestro.Pdf in export_format!(Set([MakieMaestro.Pdf]))
-
-            @testset "utils" begin
-                @test MakieMaestro.get_formats([CairoMakie], Set([MakieMaestro.Png])) ==
-                      [MakieMaestro.Png] # Allowed formats
-                if Sys.which("inkscape") !== nothing
-                    @test MakieMaestro.Svg in
-                          MakieMaestro.get_formats([CairoMakie], Set([MakieMaestro.PdfTex])) # Added necessary Svg format
-                end
-                @test_throws ArgumentError MakieMaestro.get_formats(
-                    [GLMakie], Set([MakieMaestro.Pdf])
-                )
-            end
-
-            @testset "method availability" begin
-                figexists(name) = isfile(joinpath(fig_dir, name))
-                rmfig(name) = rm(joinpath(fig_dir, name))
-                issamefig(a, b) =
-                    success(`cmp --quiet $(joinpath(fig_dir, a)) $(joinpath(fig_dir, b))`)
-
-                # Basic methods
-                savefig(fig_function)
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                savefig(fig_function_w_kwargs)
-                @test figexists("fig_function_w_kwargs.pdf")
-                rmfig("fig_function_w_kwargs.pdf")
-
-                # TODO: Add note to the documentation about the need to add the comma in order for the argument to be
-                # parsed as a tuple and not normal parens <30-01-25> 
-                savefig(fig_function, ((-π, π),))
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                if Sys.which("cmp") !== nothing # Check if UNIX system command exists
-                    savefig(fig_function, ["svg"])
-                    # NOTE: Comparison may not be made with `pdf` because the file is not the same even with the same
-                    # figure <30-01-25> 
-                    # NOTE: Different `N`. Should not be the same as `fig_function`
-                    savefig(fig_function_w_kwargs, ["svg"]; N=300)
-                    @test !issamefig("fig_function_w_kwargs.svg", "fig_function.svg")
-                    # NOTE: Same `N`. Should be the same as `fig_function`
-                    savefig(fig_function_w_kwargs, ["svg"]; N=100)
-                    @test issamefig("fig_function_w_kwargs.svg", "fig_function.svg")
-                    rmfig.(("fig_function_w_kwargs.svg", "fig_function.svg"))
-                end
-
-                if Sys.which("inkscape") !== nothing
-                    savefig(fig_function, ["pdf_tex"])
-                    @test figexists("fig_function.pdf_tex")
-                    rmfig("fig_function.pdf_tex")
-                end
-
-                # Multiple formats
-                savefig(fig_function, ["svg", MakieMaestro.Pdf])
-                @test all(figexists.(("fig_function.svg", "fig_function.pdf")))
-                rmfig.(("fig_function.svg", "fig_function.pdf"))
-
-                savefig(fig_function, "name.{pdf,png}")
-                @test all(figexists.(("name.pdf", "name.png")))
-                rmfig.(("name.pdf", "name.png"))
-
-                # Specifying a different name
-                savefig(fig_function, "other_name")
-                @test figexists("other_name.pdf")
-                rmfig("other_name.pdf")
-
-                savefig(fig_function, "other_name", ["svg", :pdf])
-                @test all(figexists.(("other_name.pdf", "other_name.svg")))
-                rmfig.(("other_name.pdf", "other_name.svg"))
-
-                # Specifying the figure directory
-                alt_fig_dir = joinpath(tempdir(), "alt_fig_dir")
-                mkdir(alt_fig_dir)
-                savefig(fig_function, "name1", alt_fig_dir)
-                savefig(fig_function, "name2", ["pdf"], alt_fig_dir)
-                savefig(fig_function, joinpath(alt_fig_dir, "name3"), ["pdf"])
-                savefig(fig_function, joinpath(alt_fig_dir, "name4.pdf"))
-                @test any(
-                    figexists.(("name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"))
-                ) == false
-                @test all(
-                    isfile.(
-                        map(
-                            n -> joinpath(alt_fig_dir, n),
-                            ["name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"],
-                        )
-                    ),
-                )
-                rm.(
-                    map(
-                        n -> joinpath(alt_fig_dir, n),
-                        ["name1.pdf", "name2.pdf", "name3.pdf", "name4.pdf"],
-                    )
-                )
-                rm(alt_fig_dir; recursive=true)
-
-                # Sizing 
-                savefig(fig_function, 100u"cm")
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                if Sys.which("cmp") !== nothing # Check if UNIX system command exists
-                    savefig(fig_function, "orig_size.svg")
-
-                    savefig(
-                        fig_function, "relative_size_one.svg", MakieMaestro.RelativeSize(1)
-                    )
-                    savefig(fig_function, "relative_size_one_notyping.svg", 1)
-                    @test issamefig("orig_size.svg", "relative_size_one.svg")
-                    @test issamefig("orig_size.svg", "relative_size_one_notyping.svg")
-
-                    savefig(fig_function, "width_same.svg", MakieMaestro.Themes.get_width())
-                    @test issamefig("orig_size.svg", "width_same.svg")
-
-                    savefig(
-                        fig_function,
-                        "hwratio_same.svg",
-                        1,
-                        MakieMaestro.Themes.get_hwratio(),
-                    )
-                    @test issamefig("orig_size.svg", "hwratio_same.svg")
-
-                    rmfig.((
-                        "orig_size.svg",
-                        "relative_size_one.svg",
-                        "width_same.svg",
-                        "hwratio_same.svg",
-                    ))
-                end
-
-                # NOTE: Warns that the error may be thrown due to SizeSpec arguments being passed to
-                # fig_function <31-01-25> 
-                using Logging
-                Logging.disable_logging(Logging.Info) # NOTE: Must enable logging after DocTests
-                # l = TestLogger()
-                # Logging.with_logger(l) do
-                #     try
-                @test_logs (:warn,) @test_throws MethodError savefig(
-                    fig_function, (100u"cm", 0.6)
-                )
-                @test_logs (:warn,) @test_throws MethodError savefig(
-                    fig_function, (0.7, 10u"cm")
-                )
-                Logging.disable_logging(Logging.Warn)
-                @test_nowarn savefig(FunctionSpec(fig_function), (10u"cm", 10u"cm"))
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                savefig(fig_function, FigHeight(100u"cm"))
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                savefig(fig_function, 100u"cm", 0.6)
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-
-                savefig(fig_function, FigHeight(100u"cm"), 0.6)
-                @test figexists("fig_function.pdf")
-                rmfig("fig_function.pdf")
-            end
-
-            # NOTE: Destroy
-            rm(fig_dir; recursive=true)
-            export_format!(missing)
-            MakieMaestro.Themes.WIDTH_DEFAULT[] = missing
-        end
+    @cond_testset "exporting" begin
+        include("exporting.jl")
     end
-    @testset "DocumenterExt" begin
-        using Documenter
-        ext = Base.get_extension(MakieMaestro, :DocumenterExt)
-        @assert !isnothing(ext)
-        @test ext.MakieBlockOptions(name="name1") == parse(ext.MakieBlockOptions, " name1")
-        @test ext.MakieBlockOptions(name="name2", basename="basename1") == parse(ext.MakieBlockOptions, " name2; basename=\"basename1\"")
-        @test ext.MakieBlockOptions(name="name2", caption="caption1") == parse(ext.MakieBlockOptions, " name2; caption=\"caption1\"")
-        @test ext.MakieBlockOptions(name="name2", basename="basename1") == parse(ext.MakieBlockOptions, " name2; formats = [:png, :pdf] , basename=\"basename1\"")
-        @test ext.MakieBlockOptions(name="name2", basename="basename1", caption="caption1") == parse(ext.MakieBlockOptions, " name2; caption = \"caption1\" , basename=\"basename1\"")
+
+    @cond_testset "documenter" begin
+        include("documenter.jl")
+    end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,5 +86,8 @@ end
     @cond_testset "documenter" begin
         include("documenter.jl")
     end
+
+    @cond_testset "recipes" begin
+        include("recipes.jl")
     end
 end

--- a/test/theming.jl
+++ b/test/theming.jl
@@ -1,0 +1,44 @@
+@testset "Constants" begin
+    using MakieMaestro.Themes
+    @test Themes.A4_HEIGHT == 297u"mm"
+    @test Themes.A11_WIDTH == 18u"mm" # Test for rounding down
+
+    @test Themes.A3_HEIGHT == Themes.A2_WIDTH == 420u"mm"
+    @test Themes.B6_WIDTH == 125u"mm"
+    @test Themes.C10_HEIGHT == 40u"mm"
+end
+@testset "merge_generate" begin
+    using MakieMaestro.Themes: merge_generate, ThemeGenerator, get_theme, THEME
+    @test THEME[][:base] isa ThemeGenerator
+    @test THEME[][:size] isa ThemeGenerator
+    @test THEME[][:format_ticks] isa ThemeGenerator
+
+    f_themegenerator = () -> Theme(; figure_padding=3)
+    @test f_themegenerator isa ThemeGenerator
+    @test theme_latexfonts isa ThemeGenerator
+    @test issame(
+        merge_generate(f_themegenerator, theme_latexfonts),
+        Theme(; figure_padding=3, fonts=theme_latexfonts()[:fonts]),
+    )
+    @test merge_generate(THEME[][:size](5u"cm", 0.5)) isa Theme
+
+    # NOTE: Test correct precedence  
+    @test issame(
+        merge_generate(THEME[][:size](5u"cm", 0.5), THEME[][:size](10u"cm", 0.5)),
+        THEME[][:size](10u"cm", 0.5),
+    )
+    # NOTE: This is inconsistent in the MakieCore package. The precedence is reversed from the `merge` on
+    # dictionaries. https://github.com/MakieOrg/Makie.jl/issues/1939
+    @test_broken Base.merge(
+        THEME[][:size](5u"cm", 0.5), THEME[][:size](10u"cm", 0.5)
+    ) == THEME[][:size](10u"cm", 0.5)
+
+    @test get_theme(:base, :rotate_labels, :orange_title) isa Theme
+    @test get_theme([:base, :rotate_labels, :orange_title]) isa Theme
+
+    @test issame(get_theme(:orange_title), get_theme([:orange_title]))
+    @test issame(
+        get_theme(:base, :rotate_labels, :orange_title),
+        get_theme([:base, :rotate_labels, :orange_title]),
+    )
+end


### PR DESCRIPTION
- **feat(CI): Configure CI to run on new commits on ready for review PR**
- **chore(git): Add .tasks to gitignore**
- **feat(CI): Julia versions "pre", "lts" and "min" in matrix**
- **docs(CI): Add comments about the necessity of DISPLAY in CI**
- **fix(compat)!: rm MakieExtra dependency and leaner compat entries**
- **add(docs): DocumenterInterLinks link to Makie documentation**
- **refactor(documenter)!: Rename `docblocks` function to `MakieDocBlocks`**
- **docs(documenter): Specify some tips and warnings about using the Documenter plugin**
- **docs(make): Explicitly use the plugin and remove doctesting**
- **fix(test): Fix the offending doctests**
- **fix(docs): Fix the location of figures with the plugin**
- **fix(compat)!: Julia 1.10 compat restriction by Makie**
- **fix: Removed method from Makie causes issue in `image` recipe**
- **test: Separate tests into files and cond testing**
- **feat: better signature and implementation for mosaic**
